### PR TITLE
feat: add global font theming

### DIFF
--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Windows.Forms;
+using V1_Trade.App.Ui;
+using V1_Trade.Screens.Settings;
 
 namespace V1_Trade.App
 {
-    public class MainForm : Form
+    public class MainForm : BaseForm
     {
         private readonly MenuStrip _menuStrip;
         private readonly StatusStrip _statusStrip;
@@ -26,8 +28,12 @@ namespace V1_Trade.App
             Controls.Add(_workspaceHost);
             Controls.Add(_statusStrip);
             Controls.Add(_menuStrip);
-
             MainMenuStrip = _menuStrip;
+
+            var settings = new ToolStripMenuItem("설정");
+            settings.DropDownItems.Add(new ToolStripMenuItem("환경설정...", (s, e) => new AppearanceForm().ShowDialog(this)));
+            _menuStrip.Items.Add(settings);
+
             Text = "V1 Trade";
             WindowState = FormWindowState.Maximized;
         }

--- a/src/App/Ui/BaseControl.cs
+++ b/src/App/Ui/BaseControl.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using V1_Trade.Infrastructure.UI;
+
+namespace V1_Trade.App.Ui
+{
+    public class BaseControl : UserControl
+    {
+        protected readonly AppThemeService ThemeService = AppThemeService.Instance;
+
+        public BaseControl()
+        {
+            DoubleBuffered = true;
+            AutoScaleMode = AutoScaleMode.Dpi;
+            ThemeService.ThemeChanged += OnThemeChanged;
+            ApplyFontRecursive(this, ThemeService.CurrentFont);
+            ControlAdded += (s, e) => ApplyFontRecursive(e.Control, ThemeService.CurrentFont);
+        }
+
+        private void OnThemeChanged(object sender, EventArgs e)
+        {
+            ApplyFontRecursive(this, ThemeService.CurrentFont);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                ThemeService.ThemeChanged -= OnThemeChanged;
+            }
+            base.Dispose(disposing);
+        }
+
+        protected void ApplyFontRecursive(Control c, Font f)
+        {
+            if (c.Font.Name != f.Name || Math.Abs(c.Font.Size - f.Size) > 0.1f)
+            {
+                c.Font = f;
+                if (c is DataGridView dgv)
+                {
+                    dgv.DefaultCellStyle.Font = f;
+                    dgv.ColumnHeadersDefaultCellStyle.Font = f;
+                    dgv.RowTemplate.Height = Math.Max(20, (int)(f.GetHeight() + 8));
+                }
+                else if (c is ToolStrip ts)
+                {
+                    ts.Font = f;
+                }
+            }
+
+            foreach (Control child in c.Controls)
+            {
+                ApplyFontRecursive(child, f);
+            }
+        }
+    }
+}

--- a/src/App/Ui/BaseForm.cs
+++ b/src/App/Ui/BaseForm.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using V1_Trade.Infrastructure.UI;
+
+namespace V1_Trade.App.Ui
+{
+    public class BaseForm : Form
+    {
+        protected readonly AppThemeService ThemeService = AppThemeService.Instance;
+
+        public BaseForm()
+        {
+            DoubleBuffered = true;
+            AutoScaleMode = AutoScaleMode.Dpi;
+            ThemeService.ThemeChanged += OnThemeChanged;
+            ApplyFontRecursive(this, ThemeService.CurrentFont);
+            ControlAdded += (s, e) => ApplyFontRecursive(e.Control, ThemeService.CurrentFont);
+        }
+
+        private void OnThemeChanged(object sender, EventArgs e)
+        {
+            ApplyFontRecursive(this, ThemeService.CurrentFont);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                ThemeService.ThemeChanged -= OnThemeChanged;
+            }
+            base.Dispose(disposing);
+        }
+
+        protected void ApplyFontRecursive(Control c, Font f)
+        {
+            if (c.Font.Name != f.Name || Math.Abs(c.Font.Size - f.Size) > 0.1f)
+            {
+                c.Font = f;
+                if (c is DataGridView dgv)
+                {
+                    dgv.DefaultCellStyle.Font = f;
+                    dgv.ColumnHeadersDefaultCellStyle.Font = f;
+                    dgv.RowTemplate.Height = Math.Max(20, (int)(f.GetHeight() + 8));
+                }
+                else if (c is ToolStrip ts)
+                {
+                    ts.Font = f;
+                }
+            }
+
+            foreach (Control child in c.Controls)
+            {
+                ApplyFontRecursive(child, f);
+            }
+        }
+    }
+}

--- a/src/App/V1_Trade.csproj
+++ b/src/App/V1_Trade.csproj
@@ -12,6 +12,8 @@
     <Compile Include="..\Infrastructure\Eventing\EventBus.cs" />
     <Compile Include="..\Infrastructure\Sequencing\SequenceService.cs" />
     <Compile Include="..\Infrastructure\UI\UIHelper.cs" />
+    <Compile Include="..\Infrastructure\UI\AppThemeService.cs" />
+    <Compile Include="..\Infrastructure\Config\Config.cs" />
     <Compile Include="..\Infrastructure\Telemetry\TelemetryClient.cs" />
     <Compile Include="..\Infrastructure\Logging\Logger.cs" />
     <Compile Include="..\Domain\Models\TradeModel.cs" />
@@ -19,7 +21,17 @@
     <Compile Include="..\Screens\QuoteBoard\QuoteBoardScreen.cs" />
     <Compile Include="..\Screens\OrderMonitor\OrderMonitorScreen.cs" />
     <Compile Include="..\Screens\PriceLadder\PriceLadderScreen.cs" />
+    <Compile Include="..\Screens\PriceLadder\PriceLadderControl.cs" />
     <Compile Include="..\Screens\TimeAndSales\TimeAndSalesScreen.cs" />
     <Compile Include="..\Screens\PositionPnL\PositionPnLScreen.cs" />
+    <Compile Include="..\Screens\Settings\AppearanceForm.cs" />
+    <Compile Include="..\Screens\Settings\AppearanceForm.Designer.cs" />
+    <Compile Include="Ui\BaseForm.cs" />
+    <Compile Include="Ui\BaseControl.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/src/App/appsettings.json
+++ b/src/App/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "Ui": {
+    "FontName": "Malgun Gothic",
+    "FontSize": 12
+  }
+}

--- a/src/Infrastructure/Config/Config.cs
+++ b/src/Infrastructure/Config/Config.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Web.Script.Serialization;
+
+namespace V1_Trade.Infrastructure.Config
+{
+    public class Config
+    {
+        private readonly string _filePath;
+        private readonly JavaScriptSerializer _serializer = new JavaScriptSerializer();
+        private Dictionary<string, object> _data;
+
+        public Config()
+        {
+            _filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json");
+            if (File.Exists(_filePath))
+            {
+                var json = File.ReadAllText(_filePath, Encoding.UTF8);
+                _data = _serializer.Deserialize<Dictionary<string, object>>(json) ?? new Dictionary<string, object>();
+            }
+            else
+            {
+                _data = new Dictionary<string, object>();
+            }
+        }
+
+        public T Get<T>(string key, T defaultValue)
+        {
+            if (TryTraverse(key, out var value))
+            {
+                try
+                {
+                    return (T)Convert.ChangeType(value, typeof(T));
+                }
+                catch
+                {
+                }
+            }
+            return defaultValue;
+        }
+
+        public void Set(string key, object value)
+        {
+            var parts = key.Split(':');
+            var current = _data;
+            for (int i = 0; i < parts.Length - 1; i++)
+            {
+                var part = parts[i];
+                if (!current.TryGetValue(part, out var next) || !(next is Dictionary<string, object> dict))
+                {
+                    dict = new Dictionary<string, object>();
+                    current[part] = dict;
+                }
+                current = dict;
+            }
+            current[parts[^1]] = value;
+            Save();
+        }
+
+        private bool TryTraverse(string key, out object value)
+        {
+            var parts = key.Split(':');
+            object current = _data;
+            foreach (var part in parts)
+            {
+                if (current is Dictionary<string, object> dict && dict.TryGetValue(part, out var next))
+                {
+                    current = next;
+                }
+                else
+                {
+                    value = null;
+                    return false;
+                }
+            }
+            value = current;
+            return true;
+        }
+
+        private void Save()
+        {
+            var json = _serializer.Serialize(_data);
+            File.WriteAllText(_filePath, json, Encoding.UTF8);
+        }
+    }
+}

--- a/src/Infrastructure/UI/AppThemeService.cs
+++ b/src/Infrastructure/UI/AppThemeService.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Drawing;
+using V1_Trade.Infrastructure.Config;
+
+namespace V1_Trade.Infrastructure.UI
+{
+    public sealed class AppThemeService
+    {
+        private readonly Config _config = new Config();
+
+        public static AppThemeService Instance { get; } = new AppThemeService();
+
+        public Font CurrentFont { get; private set; }
+
+        public event EventHandler ThemeChanged;
+
+        private AppThemeService()
+        {
+            var name = _config.Get("Ui:FontName", "Malgun Gothic");
+            var size = _config.Get("Ui:FontSize", 12f);
+            CurrentFont = new Font(name, size);
+        }
+
+        public void SetFont(string name, float size)
+        {
+            if (CurrentFont.Name == name && Math.Abs(CurrentFont.Size - size) < 0.1f)
+                return;
+
+            CurrentFont = new Font(name, size);
+            _config.Set("Ui:FontName", name);
+            _config.Set("Ui:FontSize", size);
+            ThemeChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/src/Screens/PriceLadder/PriceLadderControl.cs
+++ b/src/Screens/PriceLadder/PriceLadderControl.cs
@@ -1,0 +1,9 @@
+using V1_Trade.App.Ui;
+
+namespace V1_Trade.Screens.PriceLadder
+{
+    // TODO: implement price ladder rendering and handle theme changes
+    public class PriceLadderControl : BaseControl
+    {
+    }
+}

--- a/src/Screens/Settings/AppearanceForm.Designer.cs
+++ b/src/Screens/Settings/AppearanceForm.Designer.cs
@@ -1,0 +1,36 @@
+using System.Windows.Forms;
+using V1_Trade.App.Ui;
+
+namespace V1_Trade.Screens.Settings
+{
+    public partial class AppearanceForm : BaseForm
+    {
+        private ComboBox _fontCombo;
+        private NumericUpDown _sizeUpDown;
+        private Button _applyButton;
+        private Button _okButton;
+
+        private void InitializeComponent()
+        {
+            _fontCombo = new ComboBox { DropDownStyle = ComboBoxStyle.DropDownList, Left = 15, Top = 15, Width = 200 };
+            _sizeUpDown = new NumericUpDown { Left = 225, Top = 15, Width = 60, Minimum = 10, Maximum = 16, Value = 12 };
+            _applyButton = new Button { Text = "적용", Left = 15, Top = 50, Width = 80 };
+            _okButton = new Button { Text = "확인", Left = 105, Top = 50, Width = 80 };
+
+            _applyButton.Click += ApplyButton_Click;
+            _okButton.Click += OkButton_Click;
+
+            Controls.Add(_fontCombo);
+            Controls.Add(_sizeUpDown);
+            Controls.Add(_applyButton);
+            Controls.Add(_okButton);
+
+            Text = "환경설정";
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterParent;
+            ClientSize = new System.Drawing.Size(300, 90);
+        }
+    }
+}

--- a/src/Screens/Settings/AppearanceForm.cs
+++ b/src/Screens/Settings/AppearanceForm.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using V1_Trade.App.Ui;
+using V1_Trade.Infrastructure.UI;
+
+namespace V1_Trade.Screens.Settings
+{
+    public partial class AppearanceForm : BaseForm
+    {
+        private readonly AppThemeService _theme = AppThemeService.Instance;
+
+        public AppearanceForm()
+        {
+            InitializeComponent();
+            Load += AppearanceForm_Load;
+        }
+
+        private void AppearanceForm_Load(object sender, EventArgs e)
+        {
+            var fonts = FontFamily.Families.Select(f => f.Name).OrderBy(n => n).ToArray();
+            _fontCombo.Items.AddRange(fonts);
+            _fontCombo.SelectedItem = _theme.CurrentFont.Name;
+            _sizeUpDown.Value = (decimal)_theme.CurrentFont.Size;
+        }
+
+        private void Apply()
+        {
+            var name = _fontCombo.SelectedItem?.ToString() ?? _theme.CurrentFont.Name;
+            var size = (float)_sizeUpDown.Value;
+            _theme.SetFont(name, size);
+        }
+
+        private void ApplyButton_Click(object sender, EventArgs e)
+        {
+            Apply();
+        }
+
+        private void OkButton_Click(object sender, EventArgs e)
+        {
+            Apply();
+            Close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add AppThemeService and Config helper to persist UI font
- introduce BaseForm/BaseControl to apply fonts recursively and handle DPI
- add Appearance settings form for selecting global font
- wire up MainForm menu and include placeholder PriceLadder control

## Testing
- `dotnet build -c Release` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9298d3c88320ad73ce27bbd3f235