### PR TITLE
fix: unify configuration helper and remove legacy references

### DIFF
--- a/src/Infrastructure/Config/AppConfig.cs
+++ b/src/Infrastructure/Config/AppConfig.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 
-namespace V1_Trade.Infrastructure.Config
+namespace V1_Trade.Infrastructure.Configuration
 {
     public static class AppConfig
     {
@@ -19,7 +19,14 @@ namespace V1_Trade.Infrastructure.Config
             }
             else
             {
-                _data = new Dictionary<string, object>();
+                _data = new Dictionary<string, object>
+                {
+                    ["Ui"] = new Dictionary<string, object>
+                    {
+                        ["FontName"] = "Malgun Gothic",
+                        ["FontSize"] = 12
+                    }
+                };
                 Save();
             }
         }

--- a/src/Infrastructure/UI/AppThemeService.cs
+++ b/src/Infrastructure/UI/AppThemeService.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Drawing;
-using V1_Trade.Infrastructure.Config;
+using V1_Trade.Infrastructure.Configuration;
 
 namespace V1_Trade.Infrastructure.UI
 {


### PR DESCRIPTION
## Summary
- add centralized `AppConfig` using Newtonsoft.Json with default font settings
- update `AppThemeService` to use the new configuration namespace

## Testing
- `dotnet build V1_Trade.sln` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68baaab21e1083208d1ae941cf879462