### PR TITLE
chore: pin .NET SDK to 6.0.408

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.408",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Summary
- pin .NET SDK version to 6.0.408 via global.json for VS2019 compatibility

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bac37d0120832090ede1cb6ae37d84