### PR TITLE
chore: pin .NET 5 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.312",
-    "rollForward": "latestFeature"
+    "version": "5.0.408",
+    "rollForward": "disable"
   }
 }


### PR DESCRIPTION
## Summary
- pin global.json to .NET 5 SDK 5.0.408 with roll forward disabled

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bacf74ed188320aeceef88037fd4b3