### PR TITLE
refactor: ensure C# 7.3 compatibility in AppConfig

### DIFF
--- a/src/Infrastructure/Config/AppConfig.cs
+++ b/src/Infrastructure/Config/AppConfig.cs
@@ -55,14 +55,24 @@ namespace V1_Trade.Infrastructure.Configuration
             for (int i = 0; i < parts.Length - 1; i++)
             {
                 var part = parts[i];
-                if (!current.TryGetValue(part, out var next) || next is not Dictionary<string, object> dict)
+                if (!current.TryGetValue(part, out var next))
                 {
-                    dict = new Dictionary<string, object>();
+                    var dict = new Dictionary<string, object>();
                     current[part] = dict;
+                    current = dict;
                 }
-                current = dict;
+                else
+                {
+                    var dict = next as Dictionary<string, object>;
+                    if (dict == null)
+                    {
+                        dict = new Dictionary<string, object>();
+                        current[part] = dict;
+                    }
+                    current = dict;
+                }
             }
-            current[parts[^1]] = value;
+            current[parts[parts.Length - 1]] = value;
             Save();
         }
 


### PR DESCRIPTION
## Summary
- refactor config dictionary updates to avoid C# 9 pattern matching
- replace index-from-end operator with classic array indexing

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bad170aaec8320bde28d013946bf36