### PR TITLE
feat(ui): add global font manager

### DIFF
--- a/src/App/App.config
+++ b/src/App/App.config
@@ -1,3 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+  <appSettings>
+    <add key="Ui.Font.Name" value="Malgun Gothic" />
+    <add key="Ui.Font.Size" value="12" />
+  </appSettings>
 </configuration>

--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -1,8 +1,9 @@
 using System.Windows.Forms;
+using V1_Trade.Infrastructure.UI;
 
 namespace V1_Trade.App
 {
-    public class MainForm : Form
+    public class MainForm : BaseForm
     {
         public MainForm()
         {

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Windows.Forms;
+using V1_Trade.Infrastructure.UI;
 
 namespace V1_Trade.App
 {
@@ -10,6 +11,9 @@ namespace V1_Trade.App
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+            // Load persisted font settings before any forms are created.
+            FontManager.Instance.LoadSettings();
+
             Application.Run(new MainForm());
         }
     }

--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -16,10 +16,14 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="MainForm.cs" />
+    <Compile Include="..\Infrastructure\UI\FontManager.cs" />
+    <Compile Include="..\Infrastructure\UI\BaseForm.cs" />
+    <Compile Include="..\Infrastructure\UI\BaseControl.cs" />
     <Compile Include="Properties\\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Infrastructure/UI/BaseControl.cs
+++ b/src/Infrastructure/UI/BaseControl.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Windows.Forms;
+
+namespace V1_Trade.Infrastructure.UI
+{
+    /// <summary>
+    /// Base user control that applies global font settings.
+    /// </summary>
+    public class BaseControl : UserControl
+    {
+        public BaseControl()
+        {
+            FontManager.Instance.FontChanged += OnFontChanged;
+        }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            FontManager.Instance.ApplyFontDeep(this);
+        }
+
+        private void OnFontChanged(object sender, EventArgs e)
+        {
+            FontManager.Instance.ApplyFontDeep(this);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                FontManager.Instance.FontChanged -= OnFontChanged;
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Infrastructure/UI/BaseForm.cs
+++ b/src/Infrastructure/UI/BaseForm.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Windows.Forms;
+
+namespace V1_Trade.Infrastructure.UI
+{
+    /// <summary>
+    /// Base form that applies global font settings.
+    /// </summary>
+    public class BaseForm : Form
+    {
+        public BaseForm()
+        {
+            FontManager.Instance.FontChanged += OnFontChanged;
+        }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            FontManager.Instance.ApplyFontDeep(this);
+        }
+
+        private void OnFontChanged(object sender, EventArgs e)
+        {
+            FontManager.Instance.ApplyFontDeep(this);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                FontManager.Instance.FontChanged -= OnFontChanged;
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Infrastructure/UI/FontManager.cs
+++ b/src/Infrastructure/UI/FontManager.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Configuration;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace V1_Trade.Infrastructure.UI
+{
+    /// <summary>
+    /// Manages global font preferences for the application.
+    /// </summary>
+    public sealed class FontManager
+    {
+        private static readonly Lazy<FontManager> _instance = new Lazy<FontManager>(() => new FontManager());
+
+        public static FontManager Instance => _instance.Value;
+
+        private FontManager()
+        {
+            LoadSettings();
+        }
+
+        public string CurrentFontName { get; private set; } = "Malgun Gothic";
+        public float CurrentFontSize { get; private set; } = 12f;
+
+        public event EventHandler FontChanged;
+
+        /// <summary>
+        /// Applies current font settings to the provided control and all of its children.
+        /// </summary>
+        public void ApplyFontDeep(Control root)
+        {
+            if (root == null) return;
+
+            var font = new Font(CurrentFontName, CurrentFontSize);
+            ApplyFontRecursive(root, font);
+        }
+
+        private static void ApplyFontRecursive(Control control, Font font)
+        {
+            control.Font = font;
+            foreach (Control child in control.Controls)
+            {
+                ApplyFontRecursive(child, font);
+            }
+        }
+
+        /// <summary>
+        /// Updates the current font and notifies subscribers.
+        /// </summary>
+        public void SetFont(string name, float size)
+        {
+            if (string.Equals(name, CurrentFontName, StringComparison.Ordinal) && Math.Abs(size - CurrentFontSize) < 0.1f)
+                return;
+
+            CurrentFontName = name;
+            CurrentFontSize = size;
+            SaveSettings();
+            FontChanged?.Invoke(this, EventArgs.Empty);
+            // Apply to all open forms.
+            foreach (Form form in Application.OpenForms.Cast<Form>())
+            {
+                ApplyFontDeep(form);
+            }
+        }
+
+        /// <summary>
+        /// Loads font settings from configuration.
+        /// </summary>
+        public void LoadSettings()
+        {
+            var name = ConfigurationManager.AppSettings["Ui.Font.Name"];
+            var sizeValue = ConfigurationManager.AppSettings["Ui.Font.Size"];
+            if (!string.IsNullOrEmpty(name))
+                CurrentFontName = name;
+            if (float.TryParse(sizeValue, out var parsed))
+                CurrentFontSize = parsed;
+        }
+
+        /// <summary>
+        /// Saves font settings to configuration.
+        /// </summary>
+        public void SaveSettings()
+        {
+            var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+            config.AppSettings.Settings.Remove("Ui.Font.Name");
+            config.AppSettings.Settings.Remove("Ui.Font.Size");
+            config.AppSettings.Settings.Add("Ui.Font.Name", CurrentFontName);
+            config.AppSettings.Settings.Add("Ui.Font.Size", CurrentFontSize.ToString());
+            config.Save(ConfigurationSaveMode.Modified);
+            ConfigurationManager.RefreshSection("appSettings");
+        }
+    }
+}
+

--- a/src/Screens/Settings/AppearanceForm.cs
+++ b/src/Screens/Settings/AppearanceForm.cs
@@ -1,7 +1,9 @@
 // Placeholder
+using V1_Trade.Infrastructure.UI;
+
 namespace V1_Trade.Screens.Settings
 {
-    public class AppearanceForm
+    public class AppearanceForm : BaseForm
     {
     }
 }


### PR DESCRIPTION
## SEARCH REPORT
- `rg -n "FontManager" -g "*.cs"`: no results in repository【968d13†L1-L2】
- `rg -n "ApplyFontDeep" -g "*.cs"`: no results【f9beb8†L1-L2】
- `rg -n "Ui.Font.(Name|Size)" -g "*.cs"`: no results【83222b†L1-L2】

## REUSE PLAN / NEW PLAN
No reusable font handling existed. Implemented new `FontManager` singleton and base form/control classes to propagate global font settings and persist them.

## DELTA SUMMARY
- Added `FontManager` with font change event, recursive application, and config persistence.
- Introduced `BaseForm` and `BaseControl` that subscribe to `FontManager`.
- Updated `App.config` with `Ui.Font.Name` and `Ui.Font.Size` defaults and wired startup to load them.
- Converted `MainForm` to inherit from `BaseForm`.


------
https://chatgpt.com/codex/tasks/task_e_68bb6a709ea083209ff3fe1e09fabc48