### PR TITLE
Add WinForms 4.7.2 smoke test project

### DIFF
--- a/V1_Trade.sln
+++ b/V1_Trade.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 16.0.28701.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "V1_Trade.App", "src\\App\\V1_Trade.App.csproj", "{d414cd6a-34bb-4c7d-b220-479863802bd5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SmokeTest.WinForms472", "tests\SmokeTest.WinForms472\SmokeTest.WinForms472.csproj", "{1a9f151d-c9b2-4ccd-be6e-bf7086900a44}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|Any CPU = Debug|Any CPU
@@ -14,6 +16,10 @@ Global
         {d414cd6a-34bb-4c7d-b220-479863802bd5}.Debug|Any CPU.Build.0 = Debug|Any CPU
         {d414cd6a-34bb-4c7d-b220-479863802bd5}.Release|Any CPU.ActiveCfg = Release|Any CPU
         {d414cd6a-34bb-4c7d-b220-479863802bd5}.Release|Any CPU.Build.0 = Release|Any CPU
+        {1a9f151d-c9b2-4ccd-be6e-bf7086900a44}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {1a9f151d-c9b2-4ccd-be6e-bf7086900a44}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {1a9f151d-c9b2-4ccd-be6e-bf7086900a44}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {1a9f151d-c9b2-4ccd-be6e-bf7086900a44}.Release|Any CPU.Build.0 = Release|Any CPU
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE

--- a/tests/SmokeTest.WinForms472/App.config
+++ b/tests/SmokeTest.WinForms472/App.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+  </startup>
+</configuration>

--- a/tests/SmokeTest.WinForms472/Form1.cs
+++ b/tests/SmokeTest.WinForms472/Form1.cs
@@ -1,0 +1,12 @@
+using System.Windows.Forms;
+
+namespace SmokeTest.WinForms472
+{
+    public class Form1 : Form
+    {
+        public Form1()
+        {
+            Text = "SmokeTest WinForms 4.7.2";
+        }
+    }
+}

--- a/tests/SmokeTest.WinForms472/Program.cs
+++ b/tests/SmokeTest.WinForms472/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Windows.Forms;
+
+namespace SmokeTest.WinForms472
+{
+    internal static class Program
+    {
+        [STAThread]
+        private static void Main()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new Form1());
+        }
+    }
+}

--- a/tests/SmokeTest.WinForms472/SmokeTest.WinForms472.csproj
+++ b/tests/SmokeTest.WinForms472/SmokeTest.WinForms472.csproj
@@ -1,0 +1,36 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1a9f151d-c9b2-4ccd-be6e-bf7086900a44}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>SmokeTest.WinForms472</RootNamespace>
+    <AssemblyName>SmokeTest.WinForms472</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Form1.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
## Summary
- add minimal WinForms smoke-test project targeting .NET Framework 4.7.2
- wire new project into solution for F5 runs

## Testing
- `msbuild V1_Trade.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden; unable to install build tools)*

------
https://chatgpt.com/codex/tasks/task_e_68bb840ce6e48320baeb3d9005d405a8