### PR TITLE
Normalize solution metadata and enable debug symbols

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/V1_Trade.sln
+++ b/V1_Trade.sln
@@ -24,4 +24,7 @@ Global
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE
     EndGlobalSection
+    GlobalSection(ExtensibilityGlobals) = postSolution
+        SolutionGuid = {4E144C68-BC37-4D7B-9EF9-8FBCEF1D3CA3}
+    EndGlobalSection
 EndGlobal

--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -12,6 +12,12 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
## Summary
- add missing `SolutionGuid` and ExtensibilityGlobals block for VS2019
- enable full debug symbols for the app project
- share debug symbol defaults via `Directory.Build.props`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 – repository not signed)*

## Findings
- `V1_Trade.sln` line 3: `VisualStudioVersion = 16.0.28701.123`
- `V1_Trade.sln` lines 27-29: new `ExtensibilityGlobals` with `SolutionGuid`
- `src/App/V1_Trade.App.csproj` lines 15-20: Debug `PropertyGroup` with symbols, no optimization, `DEBUG;TRACE`
- `Directory.Build.props` lines 1-8: repo-wide Debug symbols configuration
- No `launchSettings.json` found in repo

------
https://chatgpt.com/codex/tasks/task_e_68bb8b0816148320b7231ff394bffce9