### PR TITLE
Fix project metadata for VS2019 debugging

### DIFF
--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -13,16 +13,25 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>bin\Debug\net472\</OutputPath>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>bin\Release\net472\</OutputPath>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Configuration" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/tests/SmokeTest.WinForms472/SmokeTest.WinForms472.csproj
+++ b/tests/SmokeTest.WinForms472/SmokeTest.WinForms472.csproj
@@ -13,10 +13,16 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>bin\Debug\</OutputPath>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
## Summary
- add explicit Debug/Release output groups to WinForms smoke test project
- align app project for single Newtonsoft.Json PackageReference and net472 debug/release outputs

## Testing
- `dotnet build src/App/V1_Trade.App.csproj -c Debug` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden while attempting to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68bb99490dc48320980b444c9e5822ab