### PR TITLE
Add System.Drawing reference to resolve Font compilation

### DIFF
--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -22,6 +22,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Configuration" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Infrastructure/UI/FontManager.cs
+++ b/src/Infrastructure/UI/FontManager.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Configuration;
 using System.Drawing;
+using System.Configuration;
 using System.Linq;
 using System.Windows.Forms;
 


### PR DESCRIPTION
## Summary
- include System.Drawing assembly reference in V1_Trade.App
- ensure FontManager imports System.Drawing

## Testing
- `dotnet build V1_Trade.sln` *(fails: command not found: dotnet)*
- `dotnet run --project src/App/V1_Trade.App.csproj` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68bb9fae158c8320ae1e58f4063b4cf8