### PR TITLE
chore: fix WinForms debugging paths

### DIFF
--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -13,14 +13,23 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>bin\Debug\</OutputPath>
+    <IntermediateOutputPath>obj\Debug\</IntermediateOutputPath>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <IntermediateOutputPath>obj\Release\</IntermediateOutputPath>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Configuration" />
   </ItemGroup>
@@ -34,6 +43,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/tests/SmokeTest.WinForms472/SmokeTest.WinForms472.csproj
+++ b/tests/SmokeTest.WinForms472/SmokeTest.WinForms472.csproj
@@ -13,10 +13,18 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>bin\Debug\</OutputPath>
+    <IntermediateOutputPath>obj\Debug\</IntermediateOutputPath>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
+    <IntermediateOutputPath>obj\Release\</IntermediateOutputPath>
+    <Optimize>true</Optimize>
+    <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
## Summary
- add explicit Debug/Release output paths for WinForms projects
- add System.Drawing and Newtonsoft.Json references for app project

## Testing
- `dotnet --version` *(fails: command not found)*
- `msbuild /version` *(fails: command not found)*

## Checklist
- [x] V1_Trade.App.csproj/SmokeTest.WinForms472.csproj에 Debug/Release OutputPath/IntermediateOutputPath 존재
- [x] V1_Trade.App.csproj에 System.Drawing 참조 존재
- [x] V1_Trade.App.csproj에 PackageReference Newtonsoft.Json 13.0.3 존재, HintPath 참조/packages.config 제거
- [x] FontManager.cs에 using System.Drawing; 존재
- [x] launchSettings.json 불필요 → 없음


------
https://chatgpt.com/codex/tasks/task_e_68bbac2d02a08320bb86aa97130265c7