### PR TITLE
Apply configurable global font across UI

### DIFF
--- a/src/App/App.config
+++ b/src/App/App.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="Ui.Font.Name" value="Malgun Gothic" />
-    <add key="Ui.Font.Size" value="12" />
+    <add key="UI.Font.Name" value="Malgun Gothic" />
+    <add key="UI.Font.Size" value="12pt" />
   </appSettings>
 </configuration>

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -11,8 +11,6 @@ namespace V1_Trade.App
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            // Load persisted font settings before any forms are created.
-            FontManager.Instance.LoadSettings();
 
             Application.Run(new MainForm());
         }

--- a/src/Infrastructure/UI/BaseControl.cs
+++ b/src/Infrastructure/UI/BaseControl.cs
@@ -1,36 +1,15 @@
-using System;
 using System.Windows.Forms;
 
 namespace V1_Trade.Infrastructure.UI
 {
     /// <summary>
-    /// Base user control that applies global font settings.
+    /// Base user control that applies global font settings once during construction.
     /// </summary>
     public class BaseControl : UserControl
     {
         public BaseControl()
         {
-            FontManager.Instance.FontChanged += OnFontChanged;
-        }
-
-        protected override void OnHandleCreated(EventArgs e)
-        {
-            base.OnHandleCreated(e);
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        private void OnFontChanged(object sender, EventArgs e)
-        {
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                FontManager.Instance.FontChanged -= OnFontChanged;
-            }
-            base.Dispose(disposing);
+            FontManager.ApplyFont(this);
         }
     }
 }

--- a/src/Infrastructure/UI/BaseForm.cs
+++ b/src/Infrastructure/UI/BaseForm.cs
@@ -1,36 +1,15 @@
-using System;
 using System.Windows.Forms;
 
 namespace V1_Trade.Infrastructure.UI
 {
     /// <summary>
-    /// Base form that applies global font settings.
+    /// Base form that applies global font settings once during construction.
     /// </summary>
     public class BaseForm : Form
     {
         public BaseForm()
         {
-            FontManager.Instance.FontChanged += OnFontChanged;
-        }
-
-        protected override void OnHandleCreated(EventArgs e)
-        {
-            base.OnHandleCreated(e);
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        private void OnFontChanged(object sender, EventArgs e)
-        {
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                FontManager.Instance.FontChanged -= OnFontChanged;
-            }
-            base.Dispose(disposing);
+            FontManager.ApplyFont(this);
         }
     }
 }

--- a/src/Infrastructure/UI/FontManager.cs
+++ b/src/Infrastructure/UI/FontManager.cs
@@ -1,95 +1,186 @@
 using System;
 using System.Configuration;
 using System.Drawing;
-using System.Linq;
+using System.Globalization;
+using System.IO;
 using System.Windows.Forms;
 
 namespace V1_Trade.Infrastructure.UI
 {
     /// <summary>
-    /// Manages global font preferences for the application.
+    /// Provides helpers for applying the globally configured font to controls.
     /// </summary>
-    public sealed class FontManager
+    public static class FontManager
     {
-        private static readonly Lazy<FontManager> _instance = new Lazy<FontManager>(() => new FontManager());
-
-        public static FontManager Instance => _instance.Value;
-
-        private FontManager()
-        {
-            LoadSettings();
-        }
-
-        public string CurrentFontName { get; private set; } = "Malgun Gothic";
-        public float CurrentFontSize { get; private set; } = 12f;
-
-        public event EventHandler FontChanged;
+        private static Font _cachedFont;
+        private static bool _fontLoaded;
 
         /// <summary>
-        /// Applies current font settings to the provided control and all of its children.
+        /// Reads the configured font from configuration files.
+        /// Returns <c>null</c> if parsing fails or the font cannot be created.
         /// </summary>
-        public void ApplyFontDeep(Control root)
+        public static Font GetConfiguredFontOrNull()
         {
-            if (root == null) return;
+            if (_fontLoaded)
+            {
+                return _cachedFont;
+            }
 
-            var font = new Font(CurrentFontName, CurrentFontSize);
-            ApplyFontRecursive(root, font);
+            _fontLoaded = true;
+
+            try
+            {
+                string name = null;
+                string sizeValue = null;
+
+                // 1) Try external config file.
+                var baseDir = AppDomain.CurrentDomain.BaseDirectory;
+                var externalPath = Path.Combine(baseDir, "환경 설정.config");
+                if (File.Exists(externalPath))
+                {
+                    foreach (var line in File.ReadAllLines(externalPath))
+                    {
+                        var parts = line.Split(new[] { '=' }, 2);
+                        if (parts.Length != 2)
+                            continue;
+                        var key = parts[0].Trim();
+                        var value = parts[1].Trim();
+                        if (key == "UI.Font.Name")
+                            name = value;
+                        else if (key == "UI.Font.Size")
+                            sizeValue = value;
+                    }
+                }
+
+                // 2) Fallback to App.config.
+                if (name == null)
+                    name = ConfigurationManager.AppSettings["UI.Font.Name"];
+                if (sizeValue == null)
+                    sizeValue = ConfigurationManager.AppSettings["UI.Font.Size"];
+
+                if (string.IsNullOrWhiteSpace(name))
+                    return null;
+
+                float size;
+                if (!TryParseSize(sizeValue, out size))
+                    return null;
+
+                var font = new Font(name, size);
+                _cachedFont = font;
+                return font;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
-        private static void ApplyFontRecursive(Control control, Font font)
+        /// <summary>
+        /// Applies the configured font to a control and all of its child controls.
+        /// </summary>
+        public static void ApplyFont(Control root)
         {
-            control.Font = font;
+            try
+            {
+                var font = GetConfiguredFontOrNull();
+                if (font == null || root == null)
+                    return;
+
+                ApplyToControl(root, font);
+            }
+            catch
+            {
+                // Swallow silently as requested.
+            }
+        }
+
+        /// <summary>
+        /// Applies the configured font to a ToolStrip and its items.
+        /// </summary>
+        public static void ApplyFont(ToolStrip strip)
+        {
+            try
+            {
+                var font = GetConfiguredFontOrNull();
+                if (font == null || strip == null)
+                    return;
+
+                if (!IsSameFont(strip.Font, font))
+                    strip.Font = font;
+
+                foreach (ToolStripItem item in strip.Items)
+                {
+                    ApplyToItem(item, font);
+                }
+            }
+            catch
+            {
+                // Ignore.
+            }
+        }
+
+        private static void ApplyToControl(Control control, Font font)
+        {
+            if (control is ToolStrip toolStrip)
+            {
+                ApplyFont(toolStrip);
+                return;
+            }
+
+            if (!IsSameFont(control.Font, font))
+                control.Font = font;
+
             foreach (Control child in control.Controls)
             {
-                ApplyFontRecursive(child, font);
+                ApplyToControl(child, font);
             }
         }
 
-        /// <summary>
-        /// Updates the current font and notifies subscribers.
-        /// </summary>
-        public void SetFont(string name, float size)
+        private static void ApplyToItem(ToolStripItem item, Font font)
         {
-            if (string.Equals(name, CurrentFontName, StringComparison.Ordinal) && Math.Abs(size - CurrentFontSize) < 0.1f)
+            if (item == null)
                 return;
 
-            CurrentFontName = name;
-            CurrentFontSize = size;
-            SaveSettings();
-            FontChanged?.Invoke(this, EventArgs.Empty);
-            // Apply to all open forms.
-            foreach (Form form in Application.OpenForms.Cast<Form>())
+            if (!IsSameFont(item.Font, font))
+                item.Font = font;
+
+            var dropDownItem = item as ToolStripDropDownItem;
+            if (dropDownItem != null)
             {
-                ApplyFontDeep(form);
+                foreach (ToolStripItem child in dropDownItem.DropDownItems)
+                {
+                    ApplyToItem(child, font);
+                }
+            }
+
+            var host = item as ToolStripControlHost;
+            if (host != null && host.Control != null)
+            {
+                ApplyToControl(host.Control, font);
             }
         }
 
-        /// <summary>
-        /// Loads font settings from configuration.
-        /// </summary>
-        public void LoadSettings()
+        private static bool IsSameFont(Font a, Font b)
         {
-            var name = ConfigurationManager.AppSettings["Ui.Font.Name"];
-            var sizeValue = ConfigurationManager.AppSettings["Ui.Font.Size"];
-            if (!string.IsNullOrEmpty(name))
-                CurrentFontName = name;
-            if (float.TryParse(sizeValue, out var parsed))
-                CurrentFontSize = parsed;
+            if (a == null || b == null)
+                return false;
+
+            return string.Equals(a.Name, b.Name, StringComparison.Ordinal) && Math.Abs(a.Size - b.Size) < 0.1f;
         }
 
-        /// <summary>
-        /// Saves font settings to configuration.
-        /// </summary>
-        public void SaveSettings()
+        private static bool TryParseSize(string value, out float size)
         {
-            var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
-            config.AppSettings.Settings.Remove("Ui.Font.Name");
-            config.AppSettings.Settings.Remove("Ui.Font.Size");
-            config.AppSettings.Settings.Add("Ui.Font.Name", CurrentFontName);
-            config.AppSettings.Settings.Add("Ui.Font.Size", CurrentFontSize.ToString());
-            config.Save(ConfigurationSaveMode.Modified);
-            ConfigurationManager.RefreshSection("appSettings");
+            size = 0f;
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            var trimmed = value.Trim();
+            if (trimmed.EndsWith("pt", StringComparison.OrdinalIgnoreCase))
+            {
+                trimmed = trimmed.Substring(0, trimmed.Length - 2);
+            }
+
+            return float.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out size);
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- implement static `FontManager` that reads font from optional config or App.config, caches it, and applies recursively including `ToolStrip` items
- apply configured font in `BaseForm` and `BaseControl` constructors
- configure default font settings in `App.config`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbccbb9d108320ab5467e9b270fdfa