### PR TITLE
Add basic menu, status bar with clock, and central tab control

### DIFF
--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows.Forms;
 using V1_Trade.Infrastructure.UI;
 
@@ -5,9 +6,44 @@ namespace V1_Trade.App
 {
     public class MainForm : BaseForm
     {
+        private readonly ToolStripStatusLabel _clockLabel;
+        private readonly Timer _timer;
+        private readonly TabControl _tabControl;
+
         public MainForm()
         {
             Text = "V1 Trade (Baseline)";
+
+            var menuStrip = new MenuStrip();
+            menuStrip.Items.AddRange(new ToolStripItem[]
+            {
+                new ToolStripMenuItem("선물"),
+                new ToolStripMenuItem("옵션"),
+                new ToolStripMenuItem("계좌"),
+                new ToolStripMenuItem("분석"),
+                new ToolStripMenuItem("Test"),
+                new ToolStripMenuItem("설정")
+            });
+            MainMenuStrip = menuStrip;
+            Controls.Add(menuStrip);
+
+            _clockLabel = new ToolStripStatusLabel();
+            var statusStrip = new StatusStrip();
+            statusStrip.Items.Add(_clockLabel);
+            Controls.Add(statusStrip);
+
+            _tabControl = new TabControl { Dock = DockStyle.Fill };
+            Controls.Add(_tabControl);
+
+            _timer = new Timer { Interval = 1000 };
+            _timer.Tick += (sender, args) => UpdateClock();
+            _timer.Start();
+            UpdateClock();
+        }
+
+        private void UpdateClock()
+        {
+            _clockLabel.Text = DateTime.Now.ToString("yyyy-MM-dd dddd tt h:mm:ss");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add MainForm menu strip with placeholders for trading features
- Show live clock in status bar updating every second
- Include central TabControl for future content

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd631a5608320ae3d72a34810bf64