### PR TITLE
feat(ui): align status clock to the right and unify time format

### DIFF
--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Globalization;
 using System.Windows.Forms;
 using V1_Trade.Infrastructure.UI;
 
@@ -5,9 +7,38 @@ namespace V1_Trade.App
 {
     public class MainForm : BaseForm
     {
+        private readonly StatusStrip _status = new();
+        private readonly ToolStripStatusLabel _spring = new() { Spring = true };
+        private readonly ToolStripStatusLabel _clockLabel = new();
+        private readonly Timer _timer = new();
+
         public MainForm()
         {
             Text = "V1 Trade (Baseline)";
+
+            _status.Items.Add(_spring);
+            _status.Items.Add(_clockLabel);
+            Controls.Add(_status);
+
+            _timer.Interval = 1000;
+            _timer.Tick += TimerTick;
+            _timer.Start();
+        }
+
+        private void TimerTick(object sender, EventArgs e)
+        {
+            _clockLabel.Text = DateTime.Now.ToString("yyyy-MM-dd dddd tt h:mm:ss");
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _timer.Tick -= TimerTick;
+                _timer.Dispose();
+                _status.Dispose();
+            }
+            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
## Summary
- display clock on a right-aligned status strip label
- unify the clock display format to `yyyy-MM-dd dddd tt h:mm:ss`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bc270d725083209c0a32ef7beea1c4