### PR TITLE
fix(ui): ensure MenuStrip, TabControl, and StatusStrip display correctly in MainForm

### DIFF
--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -6,6 +6,8 @@ namespace V1_Trade.App
 {
     public class MainForm : BaseForm
     {
+        private readonly MenuStrip _menu;
+        private readonly TabControl _tabs;
         private readonly StatusStrip _statusStrip;
         private readonly ToolStripStatusLabel _springLabel;
         private readonly ToolStripStatusLabel _clockLabel;
@@ -15,7 +17,14 @@ namespace V1_Trade.App
         {
             Text = "V1 Trade (Baseline)";
 
+            _menu = new MenuStrip();
+            _menu.Dock = DockStyle.Top;
+
+            _tabs = new TabControl();
+            _tabs.Dock = DockStyle.Fill;
+
             _statusStrip = new StatusStrip();
+            _statusStrip.Dock = DockStyle.Bottom;
 
             _springLabel = new ToolStripStatusLabel();
             _springLabel.Spring = true;
@@ -26,7 +35,11 @@ namespace V1_Trade.App
             _statusStrip.Items.Add(_springLabel);
             _statusStrip.Items.Add(_clockLabel);
 
+            Controls.Add(_menu);
+            Controls.Add(_tabs);
             Controls.Add(_statusStrip);
+
+            MainMenuStrip = _menu;
 
             _clockTimer = new Timer();
             _clockTimer.Interval = 1000;
@@ -57,6 +70,8 @@ namespace V1_Trade.App
             {
                 _clockTimer.Tick -= TimerTick;
                 _clockTimer.Dispose();
+                _menu.Dispose();
+                _tabs.Dispose();
                 _statusStrip.Dispose();
             }
 


### PR DESCRIPTION
## Summary
- Add MenuStrip and TabControl with proper docking
- Arrange Controls.Add order and set MainMenuStrip
- Dispose menu, tabs, and status strip in Dispose

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4571546c8320b47a1cd9efac9472