### PR TITLE
fix: add basic menu and tabs

### DIFF
--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -9,11 +9,23 @@ namespace V1_Trade.App
         private readonly StatusStrip _statusStrip;
         private readonly ToolStripStatusLabel _springLabel;
         private readonly ToolStripStatusLabel _clockLabel;
+        private readonly MenuStrip _menuStrip;
+        private readonly TabControl _tabControl;
         private readonly Timer _clockTimer;
 
         public MainForm()
         {
             Text = "V1 Trade (Baseline)";
+
+            _menuStrip = new MenuStrip();
+            _menuStrip.Items.Add(new ToolStripMenuItem("File"));
+            MainMenuStrip = _menuStrip;
+
+            _tabControl = new TabControl();
+            _tabControl.Dock = DockStyle.Fill;
+            _tabControl.TabPages.Add(new TabPage("Tab 1"));
+            _tabControl.TabPages.Add(new TabPage("Tab 2"));
+            _tabControl.TabPages.Add(new TabPage("Tab 3"));
 
             _statusStrip = new StatusStrip();
 
@@ -26,7 +38,9 @@ namespace V1_Trade.App
             _statusStrip.Items.Add(_springLabel);
             _statusStrip.Items.Add(_clockLabel);
 
+            Controls.Add(_tabControl);
             Controls.Add(_statusStrip);
+            Controls.Add(_menuStrip);
 
             _clockTimer = new Timer();
             _clockTimer.Interval = 1000;


### PR DESCRIPTION
## Summary
- ensure MainForm includes a basic menu and tab pages
- keep status strip clock functioning while tabs fill the form

## Testing
- `dotnet build` *(fails: command not found)*
- `msbuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc1f98e448320ba773b843414cae4