### PR TITLE
fix(app): align Program.cs with static FontManager and unify App.config keys

### DIFF
--- a/src/App/App.config
+++ b/src/App/App.config
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="Ui.Font.Name" value="Malgun Gothic" />
-    <add key="Ui.Font.Size" value="12" />
+    <add key="UI.Font.Enabled" value="false" />
+    <add key="UI.Font.Name" value="Malgun Gothic" />
+    <add key="UI.Font.Size" value="12" />
   </appSettings>
 </configuration>

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -11,8 +11,8 @@ namespace V1_Trade.App
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            // Load persisted font settings before any forms are created.
-            FontManager.Instance.LoadSettings();
+            // Warm-up font configuration to ensure settings are loaded early.
+            var _ = FontManager.GetConfiguredFontOrNull();
 
             Application.Run(new MainForm());
         }

--- a/src/Infrastructure/UI/BaseControl.cs
+++ b/src/Infrastructure/UI/BaseControl.cs
@@ -8,29 +8,10 @@ namespace V1_Trade.Infrastructure.UI
     /// </summary>
     public class BaseControl : UserControl
     {
-        public BaseControl()
-        {
-            FontManager.Instance.FontChanged += OnFontChanged;
-        }
-
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        private void OnFontChanged(object sender, EventArgs e)
-        {
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                FontManager.Instance.FontChanged -= OnFontChanged;
-            }
-            base.Dispose(disposing);
+            FontManager.ApplyFontDeep(this);
         }
     }
 }

--- a/src/Infrastructure/UI/BaseForm.cs
+++ b/src/Infrastructure/UI/BaseForm.cs
@@ -8,29 +8,10 @@ namespace V1_Trade.Infrastructure.UI
     /// </summary>
     public class BaseForm : Form
     {
-        public BaseForm()
-        {
-            FontManager.Instance.FontChanged += OnFontChanged;
-        }
-
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        private void OnFontChanged(object sender, EventArgs e)
-        {
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                FontManager.Instance.FontChanged -= OnFontChanged;
-            }
-            base.Dispose(disposing);
+            FontManager.ApplyFontDeep(this);
         }
     }
 }


### PR DESCRIPTION
## Summary
- load configured font via static FontManager warm-up
- remove FontManager instance event hooks in base UI classes
- standardize App.config to `UI.Font.*` keys

## Testing
- `dotnet build V1_Trade.sln -c Debug` *(fails: command not found)*
- `msbuild V1_Trade.sln /t:Build /p:Configuration=Debug` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdc59e6988320ad2af20ee1948e37