### PR TITLE
fix(ui): remove all Instance-era code and unify UI.Font.* keys

### DIFF
--- a/src/App/App.config
+++ b/src/App/App.config
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
-    <add key="Ui.Font.Name" value="Malgun Gothic" />
-    <add key="Ui.Font.Size" value="12" />
+    <add key="UI.Font.Enabled" value="true" />
+    <add key="UI.Font.Name" value="Malgun Gothic" />
+    <add key="UI.Font.Size" value="12" />
   </appSettings>
 </configuration>

--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -12,7 +12,7 @@ namespace V1_Trade.App
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             // Load persisted font settings before any forms are created.
-            FontManager.Instance.LoadSettings();
+            FontManager.LoadSettings();
 
             Application.Run(new MainForm());
         }

--- a/src/Infrastructure/UI/BaseControl.cs
+++ b/src/Infrastructure/UI/BaseControl.cs
@@ -8,29 +8,10 @@ namespace V1_Trade.Infrastructure.UI
     /// </summary>
     public class BaseControl : UserControl
     {
-        public BaseControl()
-        {
-            FontManager.Instance.FontChanged += OnFontChanged;
-        }
-
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        private void OnFontChanged(object sender, EventArgs e)
-        {
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                FontManager.Instance.FontChanged -= OnFontChanged;
-            }
-            base.Dispose(disposing);
+            FontManager.ApplyFontDeep(this);
         }
     }
 }

--- a/src/Infrastructure/UI/BaseForm.cs
+++ b/src/Infrastructure/UI/BaseForm.cs
@@ -8,29 +8,10 @@ namespace V1_Trade.Infrastructure.UI
     /// </summary>
     public class BaseForm : Form
     {
-        public BaseForm()
-        {
-            FontManager.Instance.FontChanged += OnFontChanged;
-        }
-
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        private void OnFontChanged(object sender, EventArgs e)
-        {
-            FontManager.Instance.ApplyFontDeep(this);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                FontManager.Instance.FontChanged -= OnFontChanged;
-            }
-            base.Dispose(disposing);
+            FontManager.ApplyFontDeep(this);
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove remaining FontManager instance references
- apply fonts via static helper in base UI classes
- unify app config keys and refactor FontManager to static class

## Testing
- `dotnet build` *(fails: command not found)*
- `msbuild /version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcea3ad1588320a0a57157cee3b315