### PR TITLE
fix: ensure TabControl visible and ordered

### DIFF
--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -17,17 +17,33 @@ namespace V1_Trade.App
         {
             Text = "V1 Trade (Baseline)";
 
+            SuspendLayout();
+
+            // MenuStrip
             _menuStrip = new MenuStrip();
-            _menuStrip.Items.Add(new ToolStripMenuItem("File"));
+            _menuStrip.Dock = DockStyle.Top;
+            _menuStrip.Items.Add(CreateMenuItem("Futures"));
+            _menuStrip.Items.Add(CreateMenuItem("Options"));
+            _menuStrip.Items.Add(CreateMenuItem("Accounts"));
+            _menuStrip.Items.Add(CreateMenuItem("Analytics"));
+            _menuStrip.Items.Add(CreateMenuItem("Test"));
+            _menuStrip.Items.Add(CreateMenuItem("Settings"));
             MainMenuStrip = _menuStrip;
 
+            // TabControl
             _tabControl = new TabControl();
             _tabControl.Dock = DockStyle.Fill;
-            _tabControl.TabPages.Add(new TabPage("Tab 1"));
-            _tabControl.TabPages.Add(new TabPage("Tab 2"));
-            _tabControl.TabPages.Add(new TabPage("Tab 3"));
+            _tabControl.TabPages.Clear();
+            _tabControl.TabPages.Add(new TabPage("Futures"));
+            _tabControl.TabPages.Add(new TabPage("Options"));
+            _tabControl.TabPages.Add(new TabPage("Accounts"));
+            _tabControl.TabPages.Add(new TabPage("Analytics"));
+            _tabControl.TabPages.Add(new TabPage("Test"));
+            _tabControl.TabPages.Add(new TabPage("Settings"));
 
+            // StatusStrip
             _statusStrip = new StatusStrip();
+            _statusStrip.Dock = DockStyle.Bottom;
 
             _springLabel = new ToolStripStatusLabel();
             _springLabel.Spring = true;
@@ -38,9 +54,13 @@ namespace V1_Trade.App
             _statusStrip.Items.Add(_springLabel);
             _statusStrip.Items.Add(_clockLabel);
 
+            // Add controls in specific order
             Controls.Add(_tabControl);
             Controls.Add(_statusStrip);
             Controls.Add(_menuStrip);
+
+            ResumeLayout(false);
+            PerformLayout();
 
             _clockTimer = new Timer();
             _clockTimer.Interval = 1000;
@@ -63,6 +83,13 @@ namespace V1_Trade.App
         private void UpdateClock()
         {
             _clockLabel.Text = DateTime.Now.ToString("yyyy-MM-dd dddd tt h:mm:ss");
+        }
+
+        private static ToolStripMenuItem CreateMenuItem(string text)
+        {
+            var item = new ToolStripMenuItem(text);
+            item.DropDownItems.Add("Placeholder");
+            return item;
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
## Summary
- Create MenuStrip, TabControl, and StatusStrip in strict order and dock appropriately
- Populate menu and tab control with six business items, removing legacy tabs and File menu
- Preserve status clock and add layout suspension for safer control initialization

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd06bd67c48320921a9241e4089d2b