### PR TITLE
Sync menu with tabs

### DIFF
--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -59,6 +59,8 @@ namespace V1_Trade.App
             Controls.Add(_tabControl);
             Controls.Add(_statusStrip);
 
+            WireMenuTabSync();
+
             ResumeLayout(false);
             PerformLayout();
 
@@ -68,6 +70,31 @@ namespace V1_Trade.App
 
             UpdateClock();
             _clockTimer.Start();
+        }
+
+        private void WireMenuTabSync()
+        {
+            foreach (ToolStripMenuItem menuItem in _menuStrip.Items)
+            {
+                TabPage targetPage = null;
+
+                foreach (TabPage page in _tabControl.TabPages)
+                {
+                    if (string.Equals(page.Text, menuItem.Text, StringComparison.Ordinal))
+                    {
+                        targetPage = page;
+                        break;
+                    }
+                }
+
+                if (targetPage != null)
+                {
+                    menuItem.MouseDown += (s, e) =>
+                    {
+                        _tabControl.SelectedTab = targetPage;
+                    };
+                }
+            }
         }
 
         private void TimerTick(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- Sync top-level MenuStrip entries with TabControl pages
- Wire menu clicks to activate matching tabs

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8340d5f88320ba6e3e692942c034