### PR TITLE
Add global font and color management base classes

### DIFF
--- a/src/App/FormBase.cs
+++ b/src/App/FormBase.cs
@@ -1,17 +1,18 @@
 using System;
 using System.Windows.Forms;
+using V1_Trade.Infrastructure.UI;
 
-namespace V1_Trade.Infrastructure.UI
+namespace V1_Trade.App
 {
     /// <summary>
-    /// Base form that applies global font settings.
+    /// Base form that applies the global font settings automatically.
     /// </summary>
-    public class BaseForm : Form
+    public class FormBase : Form
     {
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            FontManager.ApplyFontDeep(this);
+            FontManager.Apply(this);
         }
     }
 }

--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -1,10 +1,9 @@
 using System;
 using System.Windows.Forms;
-using V1_Trade.Infrastructure.UI;
 
 namespace V1_Trade.App
 {
-    public class MainForm : BaseForm
+    public class MainForm : FormBase
     {
         private readonly StatusStrip _statusStrip;
         private readonly ToolStripStatusLabel _springLabel;

--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -36,9 +36,10 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="MainForm.cs" />
+    <Compile Include="FormBase.cs" />
     <Compile Include="..\Infrastructure\UI\FontManager.cs" />
-    <Compile Include="..\Infrastructure\UI\BaseForm.cs" />
     <Compile Include="..\Infrastructure\UI\BaseControl.cs" />
+    <Compile Include="..\Infrastructure\UI\UIColors.cs" />
     <Compile Include="Properties\\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Infrastructure/UI/BaseControl.cs
+++ b/src/Infrastructure/UI/BaseControl.cs
@@ -11,7 +11,7 @@ namespace V1_Trade.Infrastructure.UI
         protected override void OnHandleCreated(EventArgs e)
         {
             base.OnHandleCreated(e);
-            FontManager.ApplyFontDeep(this);
+            FontManager.Apply(this);
         }
     }
 }

--- a/src/Infrastructure/UI/UIColors.cs
+++ b/src/Infrastructure/UI/UIColors.cs
@@ -1,0 +1,13 @@
+using System.Drawing;
+
+namespace V1_Trade.Infrastructure.UI
+{
+    /// <summary>
+    /// Provides global color constants for use across the UI.
+    /// </summary>
+    public static class UIColors
+    {
+        public static readonly Color Highlight = Color.Red;
+        public static readonly Color NeutralBg = Color.LightGray;
+    }
+}

--- a/src/Screens/Settings/AppearanceForm.cs
+++ b/src/Screens/Settings/AppearanceForm.cs
@@ -1,9 +1,9 @@
 // Placeholder
-using V1_Trade.Infrastructure.UI;
+using V1_Trade.App;
 
 namespace V1_Trade.Screens.Settings
 {
-    public class AppearanceForm : BaseForm
+    public class AppearanceForm : FormBase
     {
     }
 }


### PR DESCRIPTION
## Summary
- apply global fonts to all forms through new `FormBase`
- centralize font logic and color constants in `FontManager` and `UIColors`
- update projects and forms to use new base form and color helpers

## Testing
- `msbuild V1_Trade.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be0584d62483209e70611e1014c1f1