### PR TITLE
fix: remove legacy BaseForm include and update font use

### DIFF
--- a/src/App/FormBase.cs
+++ b/src/App/FormBase.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Windows.Forms;
+using V1_Trade.Infrastructure.UI;
+
+namespace V1_Trade.App
+{
+    /// <summary>
+    /// Base form that applies global font settings.
+    /// </summary>
+    public class FormBase : Form
+    {
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            FontManager.Apply(this);
+        }
+    }
+}

--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -36,8 +36,8 @@
   <ItemGroup>
     <Compile Include="Program.cs" />
     <Compile Include="MainForm.cs" />
+    <Compile Include="FormBase.cs" />
     <Compile Include="..\Infrastructure\UI\FontManager.cs" />
-    <Compile Include="..\Infrastructure\UI\BaseForm.cs" />
     <Compile Include="..\Infrastructure\UI\BaseControl.cs" />
     <Compile Include="Properties\\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- remove outdated BaseForm from App project and compile new FormBase
- call FontManager.Apply in FormBase to enable global font

## Testing
- `dotnet build V1_Trade.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be4bc4de1883209d0c454964e7ab3f