### PR TITLE
chore(app): remove legacy BaseForm reference

### DIFF
--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -37,7 +37,6 @@
     <Compile Include="Program.cs" />
     <Compile Include="MainForm.cs" />
     <Compile Include="..\Infrastructure\UI\FontManager.cs" />
-    <Compile Include="..\Infrastructure\UI\BaseForm.cs" />
     <Compile Include="..\Infrastructure\UI\BaseControl.cs" />
     <Compile Include="Properties\\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
- remove obsolete BaseForm compile entry from App project

## Testing
- `dotnet build src/App/V1_Trade.App.csproj` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68be4db3d1d88320ab0f0a89373107e9