### PR TITLE
chore: remove obsolete loadsettings call

### DIFF
--- a/src/App/Program.cs
+++ b/src/App/Program.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Windows.Forms;
-using V1_Trade.Infrastructure.UI;
-
 namespace V1_Trade.App
 {
     static class Program
@@ -11,9 +9,6 @@ namespace V1_Trade.App
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            // Load persisted font settings before any forms are created.
-            FontManager.LoadSettings();
-
             Application.Run(new MainForm());
         }
     }


### PR DESCRIPTION
## Summary
- remove outdated `FontManager.LoadSettings` invocation from application startup

## Testing
- `dotnet build V1_Trade.sln` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be59c55d1c8320938a1f3757b9925c