### PR TITLE
feat: add global font settings form

### DIFF
--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Windows.Forms;
+using V1_Trade.Screens.Settings;
 
 namespace V1_Trade.App
 {
@@ -26,7 +27,12 @@ namespace V1_Trade.App
             _menuStrip.Items.Add(CreateMenuItem("Accounts"));
             _menuStrip.Items.Add(CreateMenuItem("Analytics"));
             _menuStrip.Items.Add(CreateMenuItem("Test"));
-            _menuStrip.Items.Add(CreateMenuItem("Settings"));
+
+            var settingsItem = new ToolStripMenuItem("Settings");
+            var fontSettingsItem = new ToolStripMenuItem("Font Settings...");
+            fontSettingsItem.Click += (s, e) => new FontSettingsForm().ShowDialog(this);
+            settingsItem.DropDownItems.Add(fontSettingsItem);
+            _menuStrip.Items.Add(settingsItem);
             MainMenuStrip = _menuStrip;
 
             // TabControl

--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -40,6 +40,7 @@
     <Compile Include="..\Infrastructure\UI\FontManager.cs" />
     <Compile Include="..\Infrastructure\UI\BaseControl.cs" />
     <Compile Include="..\Infrastructure\UI\UIColors.cs" />
+    <Compile Include="..\Screens\Settings\FontSettingsForm.cs" />
     <Compile Include="Properties\\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Infrastructure/UI/FontManager.cs
+++ b/src/Infrastructure/UI/FontManager.cs
@@ -13,6 +13,35 @@ namespace V1_Trade.Infrastructure.UI
         private const float DefaultFontSize = 12f;
 
         /// <summary>
+        /// The name of the font currently applied to the UI.
+        /// </summary>
+        public static string CurrentFontName { get; private set; } = DefaultFontName;
+
+        /// <summary>
+        /// The size of the font currently applied to the UI.
+        /// </summary>
+        public static float CurrentFontSize { get; private set; } = DefaultFontSize;
+
+        static FontManager()
+        {
+            try
+            {
+                var name = ConfigurationManager.AppSettings["UI.Font.Name"];
+                if (!string.IsNullOrEmpty(name))
+                    CurrentFontName = name;
+
+                var size = ConfigurationManager.AppSettings["UI.Font.Size"];
+                if (float.TryParse(size, out var parsedSize))
+                    CurrentFontSize = parsedSize;
+            }
+            catch
+            {
+                CurrentFontName = DefaultFontName;
+                CurrentFontSize = DefaultFontSize;
+            }
+        }
+
+        /// <summary>
         /// Applies the configured font to the given control and all of its descendants.
         /// </summary>
         public static void Apply(Control root)
@@ -20,26 +49,46 @@ namespace V1_Trade.Infrastructure.UI
             if (root == null)
                 return;
 
-            string fontName = DefaultFontName;
-            float fontSize = DefaultFontSize;
+            ApplyToControl(root, CurrentFontName, CurrentFontSize);
+        }
 
-            try
+        /// <summary>
+        /// Sets the global font and optionally persists it to configuration.
+        /// </summary>
+        public static void SetFont(string name, float size, bool save)
+        {
+            if (string.IsNullOrEmpty(name))
+                return;
+
+            CurrentFontName = name;
+            CurrentFontSize = size;
+
+            if (save)
             {
-                var name = ConfigurationManager.AppSettings["UI.Font.Name"];
-                if (!string.IsNullOrEmpty(name))
-                    fontName = name;
+                try
+                {
+                    var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+                    var settings = config.AppSettings.Settings;
+                    if (settings["UI.Font.Name"] == null)
+                        settings.Add("UI.Font.Name", name);
+                    else
+                        settings["UI.Font.Name"].Value = name;
 
-                var size = ConfigurationManager.AppSettings["UI.Font.Size"];
-                if (float.TryParse(size, out var parsedSize))
-                    fontSize = parsedSize;
-            }
-            catch
-            {
-                fontName = DefaultFontName;
-                fontSize = DefaultFontSize;
+                    if (settings["UI.Font.Size"] == null)
+                        settings.Add("UI.Font.Size", size.ToString());
+                    else
+                        settings["UI.Font.Size"].Value = size.ToString();
+
+                    config.Save(ConfigurationSaveMode.Modified);
+                    ConfigurationManager.RefreshSection("appSettings");
+                }
+                catch
+                {
+                }
             }
 
-            ApplyToControl(root, fontName, fontSize);
+            foreach (Form form in Application.OpenForms)
+                Apply(form);
         }
 
         private static void ApplyToControl(Control control, string fontName, float fontSize)

--- a/src/Screens/Settings/FontSettingsForm.cs
+++ b/src/Screens/Settings/FontSettingsForm.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+using V1_Trade.App;
+using V1_Trade.Infrastructure.UI;
+
+namespace V1_Trade.Screens.Settings
+{
+    /// <summary>
+    /// Allows the user to change the global UI font.
+    /// </summary>
+    public class FontSettingsForm : FormBase
+    {
+        private readonly ComboBox _fontCombo;
+        private readonly NumericUpDown _fontSize;
+        private readonly Button _applyButton;
+        private readonly Button _saveButton;
+        private readonly Button _cancelButton;
+
+        public FontSettingsForm()
+        {
+            Text = "Font Settings";
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            StartPosition = FormStartPosition.CenterParent;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            ClientSize = new Size(300, 120);
+
+            var fontLabel = new Label();
+            fontLabel.AutoSize = true;
+            fontLabel.Text = "Font:";
+            fontLabel.Location = new Point(12, 15);
+
+            _fontCombo = new ComboBox();
+            _fontCombo.DropDownStyle = ComboBoxStyle.DropDownList;
+            _fontCombo.Location = new Point(60, 12);
+            _fontCombo.Width = 200;
+            foreach (var family in FontFamily.Families)
+                _fontCombo.Items.Add(family.Name);
+            _fontCombo.SelectedItem = FontManager.CurrentFontName;
+
+            var sizeLabel = new Label();
+            sizeLabel.AutoSize = true;
+            sizeLabel.Text = "Size:";
+            sizeLabel.Location = new Point(12, 45);
+
+            _fontSize = new NumericUpDown();
+            _fontSize.Minimum = 8;
+            _fontSize.Maximum = 24;
+            _fontSize.Location = new Point(60, 42);
+            _fontSize.Width = 60;
+            var size = FontManager.CurrentFontSize;
+            if (size < 8) size = 8;
+            if (size > 24) size = 24;
+            _fontSize.Value = (decimal)size;
+
+            _applyButton = new Button();
+            _applyButton.Text = "Apply";
+            _applyButton.Location = new Point(40, 80);
+            _applyButton.Click += (s, e) => FontManager.SetFont(_fontCombo.Text, (float)_fontSize.Value, false);
+
+            _saveButton = new Button();
+            _saveButton.Text = "Save";
+            _saveButton.Location = new Point(120, 80);
+            _saveButton.Click += (s, e) => { FontManager.SetFont(_fontCombo.Text, (float)_fontSize.Value, true); Close(); };
+
+            _cancelButton = new Button();
+            _cancelButton.Text = "Cancel";
+            _cancelButton.Location = new Point(200, 80);
+            _cancelButton.Click += (s, e) => Close();
+
+            Controls.Add(fontLabel);
+            Controls.Add(_fontCombo);
+            Controls.Add(sizeLabel);
+            Controls.Add(_fontSize);
+            Controls.Add(_applyButton);
+            Controls.Add(_saveButton);
+            Controls.Add(_cancelButton);
+
+            AcceptButton = _saveButton;
+            CancelButton = _cancelButton;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow updating global UI font with FontManager.SetFont
- add Font Settings form to change font name and size
- wire up Settings menu to open the Font Settings dialog

## Testing
- `dotnet test` *(command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68be5feebc04832093a2bc1617d79a37