### PR TITLE
Add font settings form to application

### DIFF
--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -26,7 +26,13 @@ namespace V1_Trade.App
             _menuStrip.Items.Add(CreateMenuItem("Accounts"));
             _menuStrip.Items.Add(CreateMenuItem("Analytics"));
             _menuStrip.Items.Add(CreateMenuItem("Test"));
-            _menuStrip.Items.Add(CreateMenuItem("Settings"));
+
+            var settingsItem = CreateMenuItem("Settings");
+            var fontItem = new ToolStripMenuItem("Font Settings...");
+            fontItem.Click += (s, e) => new V1_Trade.Screens.Settings.FontSettingsForm().ShowDialog(this);
+            settingsItem.DropDownItems.Add(fontItem);
+            _menuStrip.Items.Add(settingsItem);
+
             MainMenuStrip = _menuStrip;
 
             // TabControl
@@ -81,9 +87,7 @@ namespace V1_Trade.App
 
         private static ToolStripMenuItem CreateMenuItem(string text)
         {
-            var item = new ToolStripMenuItem(text);
-            item.DropDownItems.Add("Placeholder");
-            return item;
+            return new ToolStripMenuItem(text);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -40,6 +40,7 @@
     <Compile Include="..\Infrastructure\UI\FontManager.cs" />
     <Compile Include="..\Infrastructure\UI\BaseControl.cs" />
     <Compile Include="..\Infrastructure\UI\UIColors.cs" />
+    <Compile Include="..\Screens\Settings\FontSettingsForm.cs" />
     <Compile Include="Properties\\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Infrastructure/UI/FontManager.cs
+++ b/src/Infrastructure/UI/FontManager.cs
@@ -42,6 +42,37 @@ namespace V1_Trade.Infrastructure.UI
             ApplyToControl(root, fontName, fontSize);
         }
 
+        /// <summary>
+        /// Applies the specified font to all open forms and optionally
+        /// persists the selection to configuration.
+        /// </summary>
+        /// <param name="fontName">Font family name.</param>
+        /// <param name="fontSize">Font size.</param>
+        /// <param name="save">True to persist the settings.</param>
+        public static void SetFont(string fontName, float fontSize, bool save)
+        {
+            foreach (Form form in Application.OpenForms)
+                ApplyToControl(form, fontName, fontSize);
+
+            if (!save)
+                return;
+
+            try
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+                config.AppSettings.Settings.Remove("UI.Font.Name");
+                config.AppSettings.Settings.Remove("UI.Font.Size");
+                config.AppSettings.Settings.Add("UI.Font.Name", fontName);
+                config.AppSettings.Settings.Add("UI.Font.Size", fontSize.ToString());
+                config.Save(ConfigurationSaveMode.Modified);
+                ConfigurationManager.RefreshSection("appSettings");
+            }
+            catch
+            {
+                // Ignore persistence errors
+            }
+        }
+
         private static void ApplyToControl(Control control, string fontName, float fontSize)
         {
             if (control == null)

--- a/src/Screens/Settings/FontSettingsForm.cs
+++ b/src/Screens/Settings/FontSettingsForm.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace V1_Trade.Screens.Settings
+{
+    public class FontSettingsForm : V1_Trade.App.FormBase
+    {
+        private readonly ComboBox _combo;
+        private readonly NumericUpDown _num;
+        private readonly Button _apply;
+        private readonly Button _save;
+        private readonly Button _cancel;
+
+        public FontSettingsForm()
+        {
+            Text = "Font Settings";
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterParent;
+            AutoSize = true;
+            AutoSizeMode = AutoSizeMode.GrowAndShrink;
+
+            var layout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Top,
+                AutoSize = true,
+                ColumnCount = 2,
+                RowCount = 2
+            };
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+
+            layout.Controls.Add(new Label { Text = "Font:", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 0);
+            _combo = new ComboBox { DropDownStyle = ComboBoxStyle.DropDownList, Width = 200 };
+            _combo.Items.AddRange(FontFamily.Families.Select(f => f.Name).OrderBy(n => n).Cast<object>().ToArray());
+            layout.Controls.Add(_combo, 1, 0);
+
+            layout.Controls.Add(new Label { Text = "Size:", Anchor = AnchorStyles.Left, AutoSize = true }, 0, 1);
+            _num = new NumericUpDown { Minimum = 8, Maximum = 24, Value = 12, Width = 60 };
+            layout.Controls.Add(_num, 1, 1);
+
+            _combo.SelectedItem = Font.FontFamily.Name;
+            if ((decimal)Font.Size >= _num.Minimum && (decimal)Font.Size <= _num.Maximum)
+                _num.Value = (decimal)Font.Size;
+
+            var buttons = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Bottom,
+                FlowDirection = FlowDirection.RightToLeft,
+                AutoSize = true
+            };
+
+            _cancel = new Button { Text = "Cancel" };
+            _cancel.Click += (s, e) => Close();
+
+            _save = new Button { Text = "Save" };
+            _save.Click += (s, e) => { V1_Trade.Infrastructure.UI.FontManager.SetFont(_combo.Text, (float)_num.Value, true); Close(); };
+
+            _apply = new Button { Text = "Apply" };
+            _apply.Click += (s, e) => V1_Trade.Infrastructure.UI.FontManager.SetFont(_combo.Text, (float)_num.Value, false);
+
+            buttons.Controls.Add(_cancel);
+            buttons.Controls.Add(_save);
+            buttons.Controls.Add(_apply);
+
+            Controls.Add(buttons);
+            Controls.Add(layout);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `FontSettingsForm` dialog for changing UI fonts
- wire Settings menu to open the new dialog
- support applying and saving fonts via `FontManager.SetFont`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be88981bf483208060b3b2381cbaba