### PR TITLE
Add font settings dialog and integrate into main app

### DIFF
--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Windows.Forms;
+using V1_Trade.Screens.Settings;
 
 namespace V1_Trade.App
 {
@@ -15,24 +16,27 @@ namespace V1_Trade.App
         public MainForm()
         {
             Text = "V1 Trade (Baseline)";
+            KeyPreview = true;
 
             SuspendLayout();
 
             // MenuStrip
-            _menuStrip = new MenuStrip();
-            _menuStrip.Dock = DockStyle.Top;
-            _menuStrip.Items.Add(CreateMenuItem("Futures"));
-            _menuStrip.Items.Add(CreateMenuItem("Options"));
-            _menuStrip.Items.Add(CreateMenuItem("Accounts"));
-            _menuStrip.Items.Add(CreateMenuItem("Analytics"));
-            _menuStrip.Items.Add(CreateMenuItem("Test"));
-            _menuStrip.Items.Add(CreateMenuItem("Settings"));
+            _menuStrip = new MenuStrip { Dock = DockStyle.Top };
+            _menuStrip.Items.Add(CreateTabMenuItem("Futures", 0));
+            _menuStrip.Items.Add(CreateTabMenuItem("Options", 1));
+            _menuStrip.Items.Add(CreateTabMenuItem("Accounts", 2));
+            _menuStrip.Items.Add(CreateTabMenuItem("Analytics", 3));
+            _menuStrip.Items.Add(CreateTabMenuItem("Test", 4));
+
+            var settingsMenu = new ToolStripMenuItem("Settings");
+            var fontItem = new ToolStripMenuItem("Font Settings...");
+            fontItem.Click += (s, e) => new FontSettingsForm().ShowDialog(this);
+            settingsMenu.DropDownItems.Add(fontItem);
+            _menuStrip.Items.Add(settingsMenu);
             MainMenuStrip = _menuStrip;
 
             // TabControl
-            _tabControl = new TabControl();
-            _tabControl.Dock = DockStyle.Fill;
-            _tabControl.TabPages.Clear();
+            _tabControl = new TabControl { Dock = DockStyle.Fill };
             _tabControl.TabPages.Add(new TabPage("Futures"));
             _tabControl.TabPages.Add(new TabPage("Options"));
             _tabControl.TabPages.Add(new TabPage("Accounts"));
@@ -41,19 +45,15 @@ namespace V1_Trade.App
             _tabControl.TabPages.Add(new TabPage("Settings"));
 
             // StatusStrip
-            _statusStrip = new StatusStrip();
-            _statusStrip.Dock = DockStyle.Bottom;
+            _statusStrip = new StatusStrip { Dock = DockStyle.Bottom };
 
-            _springLabel = new ToolStripStatusLabel();
-            _springLabel.Spring = true;
+            _springLabel = new ToolStripStatusLabel { Spring = true };
 
-            _clockLabel = new ToolStripStatusLabel();
-            _clockLabel.Alignment = ToolStripItemAlignment.Right;
+            _clockLabel = new ToolStripStatusLabel { Alignment = ToolStripItemAlignment.Right };
 
             _statusStrip.Items.Add(_springLabel);
             _statusStrip.Items.Add(_clockLabel);
 
-            // Add controls in specific order
             Controls.Add(_menuStrip);
             Controls.Add(_tabControl);
             Controls.Add(_statusStrip);
@@ -61,8 +61,7 @@ namespace V1_Trade.App
             ResumeLayout(false);
             PerformLayout();
 
-            _clockTimer = new Timer();
-            _clockTimer.Interval = 1000;
+            _clockTimer = new Timer { Interval = 1000 };
             _clockTimer.Tick += TimerTick;
 
             UpdateClock();
@@ -79,11 +78,21 @@ namespace V1_Trade.App
             _clockLabel.Text = DateTime.Now.ToString("yyyy-MM-dd dddd tt h:mm:ss");
         }
 
-        private static ToolStripMenuItem CreateMenuItem(string text)
+        private ToolStripMenuItem CreateTabMenuItem(string text, int index)
         {
             var item = new ToolStripMenuItem(text);
-            item.DropDownItems.Add("Placeholder");
+            item.Click += (s, e) => _tabControl.SelectedIndex = index;
             return item;
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (keyData == (Keys.Control | Keys.Shift | Keys.F))
+            {
+                new FontSettingsForm().ShowDialog(this);
+                return true;
+            }
+            return base.ProcessCmdKey(ref msg, keyData);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -37,6 +37,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="MainForm.cs" />
     <Compile Include="FormBase.cs" />
+    <Compile Include="..\Screens\Settings\FontSettingsForm.cs" />
     <Compile Include="..\Infrastructure\UI\FontManager.cs" />
     <Compile Include="..\Infrastructure\UI\BaseControl.cs" />
     <Compile Include="..\Infrastructure\UI\UIColors.cs" />

--- a/src/Infrastructure/UI/FontManager.cs
+++ b/src/Infrastructure/UI/FontManager.cs
@@ -42,6 +42,32 @@ namespace V1_Trade.Infrastructure.UI
             ApplyToControl(root, fontName, fontSize);
         }
 
+        /// <summary>
+        /// Sets the global font and optionally persists the selection.
+        /// </summary>
+        public static void SetFont(string fontName, float fontSize, bool persist)
+        {
+            foreach (Form form in Application.OpenForms)
+                ApplyToControl(form, fontName, fontSize);
+
+            if (!persist)
+                return;
+
+            try
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+                var settings = config.AppSettings.Settings;
+                settings["UI.Font.Name"].Value = fontName;
+                settings["UI.Font.Size"].Value = fontSize.ToString();
+                config.Save(ConfigurationSaveMode.Modified);
+                ConfigurationManager.RefreshSection("appSettings");
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+
         private static void ApplyToControl(Control control, string fontName, float fontSize)
         {
             if (control == null)

--- a/src/Screens/Settings/FontSettingsForm.cs
+++ b/src/Screens/Settings/FontSettingsForm.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+using V1_Trade.Infrastructure.UI;
+
+namespace V1_Trade.Screens.Settings
+{
+    public class FontSettingsForm : V1_Trade.App.FormBase
+    {
+        private readonly ComboBox _fontCombo;
+        private readonly NumericUpDown _fontSize;
+        private readonly Button _apply;
+        private readonly Button _save;
+        private readonly Button _cancel;
+
+        public FontSettingsForm()
+        {
+            Text = "Font Settings";
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            StartPosition = FormStartPosition.CenterParent;
+            ClientSize = new Size(420, 200);
+
+            var layout = new TableLayoutPanel
+            {
+                Dock = DockStyle.Fill,
+                ColumnCount = 2,
+                RowCount = 3,
+                Padding = new Padding(10)
+            };
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f));
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            layout.RowStyles.Add(new RowStyle(SizeType.Percent, 100f));
+
+            layout.Controls.Add(new Label { Text = "Font", TextAlign = ContentAlignment.MiddleLeft, Dock = DockStyle.Fill }, 0, 0);
+            _fontCombo = new ComboBox { Dock = DockStyle.Fill, DropDownStyle = ComboBoxStyle.DropDownList };
+            _fontCombo.Items.AddRange(FontFamily.Families.Select(f => f.Name).ToArray());
+            layout.Controls.Add(_fontCombo, 1, 0);
+
+            layout.Controls.Add(new Label { Text = "Size", TextAlign = ContentAlignment.MiddleLeft, Dock = DockStyle.Fill }, 0, 1);
+            _fontSize = new NumericUpDown { Minimum = 8, Maximum = 32, Increment = 1, Width = 60, Dock = DockStyle.Left };
+            layout.Controls.Add(_fontSize, 1, 1);
+
+            var buttons = new FlowLayoutPanel { FlowDirection = FlowDirection.RightToLeft, Dock = DockStyle.Fill, AutoSize = true };
+            _apply = new Button { Text = "Apply" };
+            _save = new Button { Text = "Save" };
+            _cancel = new Button { Text = "Cancel" };
+            buttons.Controls.Add(_cancel);
+            buttons.Controls.Add(_save);
+            buttons.Controls.Add(_apply);
+            layout.Controls.Add(buttons, 0, 2);
+            layout.SetColumnSpan(buttons, 2);
+
+            Controls.Add(layout);
+
+            AcceptButton = _save;
+            CancelButton = _cancel;
+
+            _apply.Click += (s, e) => FontManager.SetFont(_fontCombo.Text, (float)_fontSize.Value, false);
+            _save.Click += (s, e) => { FontManager.SetFont(_fontCombo.Text, (float)_fontSize.Value, true); Close(); };
+            _cancel.Click += (s, e) => Close();
+
+            var currentFont = Font;
+            _fontCombo.SelectedItem = currentFont.FontFamily.Name;
+            _fontSize.Value = (decimal)currentFont.Size;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add configurable FontSettingsForm with font family and size controls
- Wire up Settings menu and Ctrl+Shift+F shortcut to open FontSettingsForm
- Persist selected font via FontManager.SetFont and update global UI

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be900f0c48832092bd216d7e7a7135