### PR TITLE
Add persistent font settings dialog and manager

### DIFF
--- a/src/App/FontSettingsForm.cs
+++ b/src/App/FontSettingsForm.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+using System.Windows.Forms;
+using V1_Trade.Infrastructure.UI;
+
+namespace V1_Trade.App
+{
+    /// <summary>
+    /// Dialog for configuring the application's global font.
+    /// </summary>
+    public class FontSettingsForm : FormBase
+    {
+        private readonly TextBox _nameBox;
+        private readonly TextBox _sizeBox;
+        private readonly Button _applyButton;
+        private readonly Button _saveButton;
+        private readonly Button _cancelButton;
+
+        public FontSettingsForm()
+        {
+            Text = "Font Settings";
+
+            var nameLabel = new Label { Text = "Font Name:", AutoSize = true };
+            _nameBox = new TextBox { Width = 200 };
+
+            var sizeLabel = new Label { Text = "Font Size:", AutoSize = true };
+            _sizeBox = new TextBox { Width = 60 };
+
+            _applyButton = new Button { Text = "Apply" };
+            _saveButton = new Button { Text = "Save" };
+            _cancelButton = new Button { Text = "Cancel" };
+
+            _applyButton.Click += ApplyClick;
+            _saveButton.Click += SaveClick;
+            _cancelButton.Click += (s, e) => Close();
+
+            var layout = new TableLayoutPanel();
+            layout.Dock = DockStyle.Fill;
+            layout.AutoSize = true;
+            layout.ColumnCount = 2;
+            layout.RowCount = 3;
+
+            layout.Controls.Add(nameLabel, 0, 0);
+            layout.Controls.Add(_nameBox, 1, 0);
+            layout.Controls.Add(sizeLabel, 0, 1);
+            layout.Controls.Add(_sizeBox, 1, 1);
+
+            var buttons = new FlowLayoutPanel();
+            buttons.FlowDirection = FlowDirection.RightToLeft;
+            buttons.Dock = DockStyle.Fill;
+            buttons.Controls.Add(_cancelButton);
+            buttons.Controls.Add(_saveButton);
+            buttons.Controls.Add(_applyButton);
+
+            layout.Controls.Add(buttons, 0, 2);
+            layout.SetColumnSpan(buttons, 2);
+
+            Controls.Add(layout);
+
+            AcceptButton = _saveButton;
+            CancelButton = _cancelButton;
+            StartPosition = FormStartPosition.CenterParent;
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            _nameBox.Text = FontManager.CurrentFontName;
+            _sizeBox.Text = FontManager.CurrentFontSize.ToString();
+        }
+
+        private void ApplyClick(object sender, EventArgs e)
+        {
+            ApplyFont();
+        }
+
+        private void SaveClick(object sender, EventArgs e)
+        {
+            ApplyFont();
+            FontManager.Save();
+            Close();
+        }
+
+        private void ApplyFont()
+        {
+            var name = _nameBox.Text.Trim();
+            if (!TryParseSize(_sizeBox.Text, out var size))
+                size = FontManager.CurrentFontSize;
+
+            FontManager.SetFont(name, size);
+
+            foreach (Form form in Application.OpenForms.Cast<Form>())
+                FontManager.Apply(form);
+        }
+
+        private static bool TryParseSize(string text, out float size)
+        {
+            size = 0f;
+            if (string.IsNullOrWhiteSpace(text))
+                return false;
+
+            text = text.Trim();
+            if (text.EndsWith("pt", StringComparison.OrdinalIgnoreCase))
+                text = text.Substring(0, text.Length - 2);
+
+            return float.TryParse(text, out size);
+        }
+    }
+}
+

--- a/src/App/MainForm.cs
+++ b/src/App/MainForm.cs
@@ -21,12 +21,19 @@ namespace V1_Trade.App
             // MenuStrip
             _menuStrip = new MenuStrip();
             _menuStrip.Dock = DockStyle.Top;
-            _menuStrip.Items.Add(CreateMenuItem("Futures"));
-            _menuStrip.Items.Add(CreateMenuItem("Options"));
-            _menuStrip.Items.Add(CreateMenuItem("Accounts"));
-            _menuStrip.Items.Add(CreateMenuItem("Analytics"));
-            _menuStrip.Items.Add(CreateMenuItem("Test"));
-            _menuStrip.Items.Add(CreateMenuItem("Settings"));
+            _menuStrip.Items.Add(new ToolStripMenuItem("Futures"));
+            _menuStrip.Items.Add(new ToolStripMenuItem("Options"));
+            _menuStrip.Items.Add(new ToolStripMenuItem("Accounts"));
+            _menuStrip.Items.Add(new ToolStripMenuItem("Analytics"));
+            _menuStrip.Items.Add(new ToolStripMenuItem("Test"));
+
+            var settingsMenu = new ToolStripMenuItem("Settings");
+            var fontMenu = new ToolStripMenuItem("Font Settings...");
+            fontMenu.ShortcutKeys = Keys.Control | Keys.Shift | Keys.F;
+            fontMenu.Click += FontSettingsClick;
+            settingsMenu.DropDownItems.Add(fontMenu);
+            _menuStrip.Items.Add(settingsMenu);
+
             MainMenuStrip = _menuStrip;
 
             // TabControl
@@ -79,11 +86,10 @@ namespace V1_Trade.App
             _clockLabel.Text = DateTime.Now.ToString("yyyy-MM-dd dddd tt h:mm:ss");
         }
 
-        private static ToolStripMenuItem CreateMenuItem(string text)
+        private void FontSettingsClick(object sender, EventArgs e)
         {
-            var item = new ToolStripMenuItem(text);
-            item.DropDownItems.Add("Placeholder");
-            return item;
+            using (var dlg = new FontSettingsForm())
+                dlg.ShowDialog(this);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/App/V1_Trade.App.csproj
+++ b/src/App/V1_Trade.App.csproj
@@ -33,14 +33,15 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Configuration" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Program.cs" />
-    <Compile Include="MainForm.cs" />
-    <Compile Include="FormBase.cs" />
-    <Compile Include="..\Infrastructure\UI\FontManager.cs" />
-    <Compile Include="..\Infrastructure\UI\BaseControl.cs" />
-    <Compile Include="..\Infrastructure\UI\UIColors.cs" />
-    <Compile Include="Properties\\AssemblyInfo.cs" />
+    <ItemGroup>
+      <Compile Include="Program.cs" />
+      <Compile Include="MainForm.cs" />
+      <Compile Include="FontSettingsForm.cs" />
+      <Compile Include="FormBase.cs" />
+      <Compile Include="..\Infrastructure\UI\FontManager.cs" />
+      <Compile Include="..\Infrastructure\UI\BaseControl.cs" />
+      <Compile Include="..\Infrastructure\UI\UIColors.cs" />
+      <Compile Include="Properties\\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/src/Infrastructure/UI/FontManager.cs
+++ b/src/Infrastructure/UI/FontManager.cs
@@ -12,6 +12,54 @@ namespace V1_Trade.Infrastructure.UI
         private const string DefaultFontName = "맑은 고딕";
         private const float DefaultFontSize = 12f;
 
+        private static string _currentFontName = DefaultFontName;
+        private static float _currentFontSize = DefaultFontSize;
+
+        static FontManager()
+        {
+            try
+            {
+                var name = ConfigurationManager.AppSettings["UI.Font.Name"];
+                if (!string.IsNullOrEmpty(name))
+                    _currentFontName = name;
+
+                var size = ConfigurationManager.AppSettings["UI.Font.Size"];
+                if (float.TryParse(size, out var parsedSize))
+                    _currentFontSize = parsedSize;
+            }
+            catch
+            {
+                _currentFontName = DefaultFontName;
+                _currentFontSize = DefaultFontSize;
+            }
+        }
+
+        public static string CurrentFontName => _currentFontName;
+        public static float CurrentFontSize => _currentFontSize;
+
+        public static void SetFont(string fontName, float fontSize)
+        {
+            if (!string.IsNullOrEmpty(fontName))
+                _currentFontName = fontName;
+            _currentFontSize = fontSize;
+        }
+
+        public static void Save()
+        {
+            try
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
+                config.AppSettings.Settings["UI.Font.Name"].Value = _currentFontName;
+                config.AppSettings.Settings["UI.Font.Size"].Value = _currentFontSize.ToString();
+                config.Save(ConfigurationSaveMode.Modified);
+                ConfigurationManager.RefreshSection("appSettings");
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+
         /// <summary>
         /// Applies the configured font to the given control and all of its descendants.
         /// </summary>
@@ -20,26 +68,7 @@ namespace V1_Trade.Infrastructure.UI
             if (root == null)
                 return;
 
-            string fontName = DefaultFontName;
-            float fontSize = DefaultFontSize;
-
-            try
-            {
-                var name = ConfigurationManager.AppSettings["UI.Font.Name"];
-                if (!string.IsNullOrEmpty(name))
-                    fontName = name;
-
-                var size = ConfigurationManager.AppSettings["UI.Font.Size"];
-                if (float.TryParse(size, out var parsedSize))
-                    fontSize = parsedSize;
-            }
-            catch
-            {
-                fontName = DefaultFontName;
-                fontSize = DefaultFontSize;
-            }
-
-            ApplyToControl(root, fontName, fontSize);
+            ApplyToControl(root, _currentFontName, _currentFontSize);
         }
 
         private static void ApplyToControl(Control control, string fontName, float fontSize)


### PR DESCRIPTION
## Summary
- ensure MainForm always exposes `Settings -> Font Settings...` with shortcut
- add `FontSettingsForm` dialog to adjust and persist global font
- extend `FontManager` with current font state, apply, and save support

## Testing
- `dotnet build V1_Trade.sln` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68be993b12488320bf5b099a0765c693